### PR TITLE
Add packages as runtime dependency

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,5 +7,4 @@ BBFILE_PRIORITY_otbr= "7"
 
 LAYERSERIES_COMPAT_otbr= "hardknott gatesgarth"
 
-IMAGE_INSTALL:append = " jsoncpp otbr matter openthread ${@bb.utils.contains('MACHINE_FEATURES', 'trusty', 'storageproxyd', '', d)} "
 HOSTTOOLS += " npm node python3 python "

--- a/recipes-matter/matter/matter.bb
+++ b/recipes-matter/matter/matter.bb
@@ -12,7 +12,7 @@ SRCREV = "f615a797b2fe52d5f3f8fe7dfee0469d671bad9b"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
 DEPENDS += " gn-native ninja-native avahi python3-native dbus-glib-native pkgconfig-native "
-RDEPENDS_${PN} += " libavahi-client "
+RDEPENDS_${PN} += " libavahi-client jsoncpp otbr matter openthread ${@bb.utils.contains('MACHINE_FEATURES', 'trusty', 'storageproxyd', '', d)} "
 
 DEPLOY_TRUSTY = "${@bb.utils.contains('MACHINE_FEATURES', 'trusty', 'true', 'false', d)}"
 


### PR DESCRIPTION
Add packages as RDEPENDS in the recipe instead of forcing to be installed in the image.
