### PR TITLE
Kirkstone LTS support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -2,10 +2,11 @@ BBPATH .= ":${LAYERDIR}"
 
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_PATTERN_otbr:= "^${LAYERDIR}/"
-BBFILE_PRIORITY_otbr= "7"
+BBFILE_COLLECTIONS += "matter"
+BBFILE_PATTERN_matter:= "^${LAYERDIR}/"
+BBFILE_PRIORITY_matter= "7"
 
-LAYERSERIES_COMPAT_otbr= "hardknott gatesgarth"
+LAYERSERIES_COMPAT_matter= "kirkstone"
 
 IMAGE_INSTALL:append = " jsoncpp otbr matter openthread ${@bb.utils.contains('MACHINE_FEATURES', 'trusty', 'storageproxyd', '', d)} "
 HOSTTOOLS += " npm node python3 python "

--- a/recipes-matter/matter/matter.bb
+++ b/recipes-matter/matter/matter.bb
@@ -12,7 +12,7 @@ SRCREV = "f615a797b2fe52d5f3f8fe7dfee0469d671bad9b"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
 DEPENDS += " gn-native ninja-native avahi python3-native dbus-glib-native pkgconfig-native "
-RDEPENDS_${PN} += " libavahi-client "
+RDEPENDS:${PN} += " libavahi-client "
 
 DEPLOY_TRUSTY = "${@bb.utils.contains('MACHINE_FEATURES', 'trusty', 'true', 'false', d)}"
 
@@ -275,4 +275,4 @@ do_install() {
     fi
 }
 
-INSANE_SKIP_${PN} = "ldflags"
+INSANE_SKIP:${PN} = "ldflags"

--- a/recipes-openthread/openthread/openthread.bb
+++ b/recipes-openthread/openthread/openthread.bb
@@ -9,11 +9,11 @@ SRC_URI = "gitsm://github.com/openthread/openthread.git;branch=main;protocol=htt
 SRCREV = "2ce3d3bf0218566484be2e9943b95c755cefebe3"
 
 S = "${WORKDIR}/git"
-#FILES_${PN} += "lib/systemd"
-#FILES_${PN} += "usr/share"
+#FILES:${PN} += "lib/systemd"
+#FILES:${PN} += "usr/share"
 
 DEPENDS += " avahi boost "
-RDEPENDS_${PN} += " libavahi-client "
+RDEPENDS:${PN} += " libavahi-client "
 
 TARGET_CFLAGS += " -Wno-error "
 def get_rcp_bus(d):


### PR DESCRIPTION
Fixed layer naming and compatibility with the latest LTS release. Please merge this into a separate branch or to the master and then create a tag called Kirkstone to maintain general compatibility with the yocto project. Thank you!


Also it would be nice to add dependencies for:

```
https://github.com/kraj/meta-clang.git
https://github.com/OSSystems/meta-browser/tree/master/meta-chromium
```

In the `layer.conf` since they are needed for a successful build :)